### PR TITLE
Symlink libGLESv1_CM to libGLES_CM

### DIFF
--- a/fbdev/glibc/lib64/libGLESv1_CM.so
+++ b/fbdev/glibc/lib64/libGLESv1_CM.so
@@ -1,0 +1,1 @@
+libGLES_CM.so

--- a/fbdev/glibc/lib64/libGLESv1_CM.so.1
+++ b/fbdev/glibc/lib64/libGLESv1_CM.so.1
@@ -1,0 +1,1 @@
+libGLES_CM.so


### PR DESCRIPTION
This fixes an error when trying to build VLC (needed for ES)